### PR TITLE
decrease time for stale (60 -> 14 days) and close (14 -> 7 days)

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -21,7 +21,7 @@ jobs:
           If you find that this is still a problem, please feel free to provide a comment or upvote
           with a reaction on the initial post to prevent automatic closure. If the issue is already closed,
           please feel free to open a new one.
-        stale-issue-message: Hello 👋! It looks like this issue hasn’t been active in longer than two months.
+        stale-issue-message: Hello 👋! It looks like this issue hasn’t been active in longer than two weeks.
           We encourage you to check if this is still an issue in the latest release.
           In the absence of more information, we will be closing this issue soon.
           If you find that this is still a problem, please feel free to provide a comment or upvote
@@ -37,8 +37,8 @@ jobs:
         closed-for-staleness-label: "status: resolved/stale"
 
         # Issue timing
-        days-before-stale: 60
-        days-before-close: 14
+        days-before-stale: 14
+        days-before-close: 7
         days-before-ancient: 150
 
         # If you don't want to mark a issue as being ancient based on a


### PR DESCRIPTION
As discussed with @thrau, the current stale bot configuration is not very strict.
We would like to decrease the time it takes until an issue is handled by the tale bot.

This is why this PR decreases:
- the time before an issue becomes marked as "stale" from 60 days to 14 days
- the time before a stale issue gets closed from 14 days to 7 days

These changes currently don't have any effect, since no repo has been onboarded to this workflow yet, but we'll start onboarding our repos in the next week. Then the new configuration will become effective.

Happy for any feedback!