### PR TITLE
Add workflow and nag script

### DIFF
--- a/.github/workflows/release-nag.yml
+++ b/.github/workflows/release-nag.yml
@@ -1,6 +1,7 @@
 name: Nag for PR updates
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       release-version:

--- a/.github/workflows/release-nag.yml
+++ b/.github/workflows/release-nag.yml
@@ -1,0 +1,25 @@
+name: Nag for PR updates
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: Release version
+        required: false
+        type: string
+      command:
+        description: Command to run, either "no-milestone" to check PRs with no milestone, or "merge-near" to check the status of PRs with the target milestone
+        required: true
+        type: choice
+        options:
+          - no-milestone
+          - merge-near
+
+jobs:
+  nag:
+    name: Nag users for updates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run the nag script
+        run: bash ./scripts/nag.sh ${{ inputs.command }} ${{ inputs.release-version }}

--- a/.github/workflows/release-nag.yml
+++ b/.github/workflows/release-nag.yml
@@ -1,7 +1,9 @@
 name: Nag for PR updates
 
+env:
+  GH_TOKEN: ${{ github.token }}
+
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       release-version:

--- a/.github/workflows/upgrade-python-dependencies.yml
+++ b/.github/workflows/upgrade-python-dependencies.yml
@@ -1,0 +1,37 @@
+name: Upgrade pinned Python dependencies
+
+on:
+  workflow_call:
+    secrets:
+      github-token:
+        required: true
+        description: A GitHub token with access to the issues of the calling repo
+
+jobs:
+  upgrade-dependencies:
+    name: Upgrade Pinned Python Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Upgrade all requirements files
+        run: make upgrade-all-reqs
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: "Upgrade pinned Python dependencies"
+          body: "This PR upgrades all the pinned Python dependencies."
+          branch: "upgrade-dependencies"
+          author: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
+          committer: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
+          commit-message: "Upgrade pinned Python dependencies"
+          labels: "area: dependencies, semver: patch"
+          token: ${{ secrets.github-token }}

--- a/README.md
+++ b/README.md
@@ -128,3 +128,47 @@ jobs:
     secrets:
       github-token: ${{ secrets.REPO_ACCESS_PAT }}
 ```
+## upgrade-python-dependencies
+
+This reusable workflow adds an automated upgrade of dependencies in python repositories.
+As a prerequisite the repository must define the make target `upgrade-all-deps` which should produce some kind of lock file checked in into the repository.
+
+```yaml
+name: Upgrade pinned Python dependencies
+
+on:
+  workflow_call:
+    secrets:
+      github-token:
+        required: true
+        description: A GitHub token with access to the issues of the calling repo
+
+jobs:
+  upgrade-dependencies:
+    name: Upgrade Pinned Python Dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Upgrade all requirements files
+        run: make upgrade-all-reqs
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: "Upgrade pinned Python dependencies"
+          body: "This PR upgrades all the pinned Python dependencies."
+          branch: "upgrade-dependencies"
+          author: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
+          committer: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
+          commit-message: "Upgrade pinned Python dependencies"
+          labels: "area: dependencies, semver: patch"
+          token: ${{ secrets.github-token }}
+```

--- a/scripts/nag.sh
+++ b/scripts/nag.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function merge_near() {
+    milestone="$1"
+jq -r -n \
+--argjson localstack "$(gh pr list --search "milestone:${milestone}" --json number,author,milestone,isCrossRepository,url --repo localstack/localstack --limit 500)" \
+--argjson localstack_ext "$(gh pr list --search "milestone:${milestone}" --json number,author,milestone,isCrossRepository,url --repo localstack/localstack-ext --limit 500)" \
+"[\$localstack + \$localstack_ext | .[] | select (.isCrossRepository | not)] | group_by(.author.login) | map({ author: (if .[0].author.name != \"\" then .[0].author.name else .[0].author.login end), prs: [.[] | .url] }) | .[] | \">>>>>> \(.author)\nHey! I can see you have these PRs:\n\(.prs | join(\"\n\"))\nleft open for v${milestone}. Please get back to me with their state as soon as possible, so I can track it for the release.\nThanks!\n\""
+}
+
+function no_milestone() {
+     jq -r -n \
+--argjson localstack "$(gh pr list --search "no:milestone" --json number,author,milestone,isCrossRepository,url --repo localstack/localstack --limit 500)" \
+--argjson localstack_ext "$(gh pr list --search "no:milestone" --json number,author,milestone,isCrossRepository,url --repo localstack/localstack-ext --limit 500)" \
+"[\$localstack + \$localstack_ext | .[] | select (.isCrossRepository | not)] | group_by(.author.login) | map({ author: (if .[0].author.name != \"\" then .[0].author.name else .[0].author.login end), prs: [.[] | .url] }) | .[] | \">>>>>> \(.author)\nHey! I can see you have these PRs open:\n\(.prs | join(\"\n\"))\nwithout a milestone. Please add a milestone for it (either a specific version, or Playground) as soon as possible, so I can track it for the release.\nFor more information regarding the milestones, please take a look at the notion page (https://www.notion.so/localstack/v3-1-0-91633b885871426bb1e9c4ee4ed7928d) or reach out directly to me. I'm happy to help! 🙂\nThanks!🚀\n\""
+}
+
+function main() {
+    if [[ -z "${1-}" ]]; then
+        echo "Usage: $0 <command> [<milestone>]" >&2
+        exit 1
+    fi
+
+    case "$1" in
+        no-milestone)
+            no_milestone
+            ;;
+        merge-near)
+            if [[ -z "${2-}" ]]; then
+                echo "Usage: $0 <command> [<milestone>]" >&2
+                exit 1
+            fi
+            merge_near "$2"
+            ;;
+        *)
+            echo "invalid command" >&2
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
# Motivation

When a new release is getting ready, we should be able to automate nagging users to update their PRs to accurately reflect the work that should be included.

@dfangl created a script that can be run to nag users about their PRs and classification. This PR adds that script as a github action that we can maintain and run.

There are two commands:
* `no-milestone` should be run first, at the start of the week containing a release. This prints a list of PRs per user that have no milestone associated. The users can then update their PRs to reflect the release versions of their PRs.
* `merge-near` should be run nearer the time of release, and takes the release version as an input. It prints a list of PRs that have the release as their milestones, and asks for an update on their status.
