### PR TITLE
add validate-codeowners action and related tests

### DIFF
--- a/.github/workflows/codeowner_files/CORRECT_CODEOWNERS
+++ b/.github/workflows/codeowner_files/CORRECT_CODEOWNERS
@@ -1,0 +1,2 @@
+
+/.github/workflows/validate-codeowners.yml @lukqw

--- a/.github/workflows/codeowner_files/WRONG_CODEOWNERS
+++ b/.github/workflows/codeowner_files/WRONG_CODEOWNERS
@@ -1,0 +1,2 @@
+
+/random/path/that/does/not/exist @lukqw

--- a/.github/workflows/test-validate-codeowners.yml
+++ b/.github/workflows/test-validate-codeowners.yml
@@ -1,0 +1,27 @@
+name: LocalStack SaaS Meta - Test Codeowners Validation Action
+
+on:
+  push:
+    paths:
+      - ".github/workflows/codeowner_files/*"
+      - ".github/workflows/validate-codeowners.yml"
+    branches:
+      - main
+  pull_request:
+    paths:
+      - ".github/workflows/codeowner_files/*"
+      - ".github/workflows/validate-codeowners.yml"
+    branches:
+      - main
+
+jobs:
+  check-if-action-fails-with-wrong-codeowners-file:
+    uses: ./.github/workflows/validate-codeowners.yml
+    with: 
+      codeowners-file: './.github/workflows/codeowner_files/WRONG_CODEOWNERS'
+
+    
+  check-if-action-succeeds-with-correct-codeowners-file:
+    uses: ./.github/workflows/validate-codeowners.yml
+    with: 
+      codeowners-file: './.github/workflows/codeowner_files/CORRECT_CODEOWNERS'

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,0 +1,35 @@
+name: LocalStack - Validate Codeowners
+
+on:
+  workflow_call:
+    inputs:
+      codeowners-file:
+        required: false
+        type: string
+        description: "path to the codeowners file"
+        default: ".github/CODEOWNERS"
+
+
+jobs:
+  validate-codeowners:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install npm
+        uses: actions/setup-node@v4
+
+      - name: Install snyk codeowners validator
+        run: |
+          npm i -g github-codeowners
+
+      - name: Run snyk validate command
+        run: |
+          RESULT=$(github-codeowners validate -c ${{ inputs.codeowners-file }} 2>&1)
+          if [ -n "$RESULT" ]; then
+            echo "$RESULT"
+            exit 1
+          else
+            echo "Codeowners file is valid"
+          fi

--- a/README.md
+++ b/README.md
@@ -172,3 +172,25 @@ jobs:
           labels: "area: dependencies, semver: patch"
           token: ${{ secrets.github-token }}
 ```
+
+## validate-codeowners
+
+This workflow can be used to validate whether the codeowners file is still valid
+
+```yaml
+name: LocalStack - Validate Codeowners
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  validate-codeowners:
+    uses: localstack/meta/.github/workflows/validate-codeowners.yml@main
+    with:
+      codeowners-file: './CODEOWNERS'
+```


### PR DESCRIPTION
## Context

This PR introduces a new reusable workflow which checks whether the `CODEOWNERS` file of a repository is valid.
This should be called from other repos, to ensure that `CODEOWNERS` files do not get outdated due to changes in PRs.

## Inputs
To support non-default `CODEOWNERS` file location, the `codeowners-file` argument can be passed to perform validation on a different path than the default - which is `.github/CODEOWNERS`.

## Tests
This PR further introduces two test cases, which verify that the action:
* fails in case the codeowners file is invalid
* succeeds in case the codeowners file is valid

## Sample usages
```
name: LocalStack - Validate Codeowners

on:
  push:
    branches:
      - main
  pull_request:
    branches:
      - main

jobs:
  validate-codeowners:
    uses: localstack/meta/.github/workflows/validate-codeowners.yml@add-validate-codeowners
```

## Follow up steps:
* Roll out action across localstack repos