### PR TITLE
Produce artifact with all features files from repository

### DIFF
--- a/.github/workflows/create-artifact-with-features-files.yml
+++ b/.github/workflows/create-artifact-with-features-files.yml
@@ -1,0 +1,30 @@
+name: Artifact with features files
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        type: string
+        required: true
+      aws_services_path:
+        description: 'Directory containing AWS service implementations in the localstack repository'
+        type: string
+        required: true
+
+jobs:
+  create-artifact-with-features-files:
+    name: Create artifact with features files
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout current repository
+        uses: actions/checkout@v4
+
+      - name: Create artifact
+        uses: actions/upload-artifact@v4
+        with:
+            name: ${{ inputs.artifact_name }}
+            retention-days: 2
+            if-no-files-found: ignore
+            path: |
+              ${{ inputs.aws_services_path }}/**/features.yml

--- a/.github/workflows/create-artifact-with-features-files.yml
+++ b/.github/workflows/create-artifact-with-features-files.yml
@@ -1,4 +1,4 @@
-name: Artifact with features files
+name: AWS / Archive feature files
 
 on:
   workflow_call:


### PR DESCRIPTION
This PR adds a reusable CI/CD workflow for generating artifacts containing `features.yml` files (also known as feature catalog files). This workflow will be utilized in both the `localstack/localstack` and `localstack/localstack-ext` repositories, as demonstrated in [this example](https://github.com/k-a-il/localstack/blob/master/.github/workflows/create-artifact.yml).