### PR TITLE
Temporarily pin pip to v25.0

### DIFF
--- a/.github/workflows/upgrade-python-dependencies.yml
+++ b/.github/workflows/upgrade-python-dependencies.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           python-version: "3.11"
 
+      # FIXME remove this pin once https://github.com/jazzband/pip-tools/issues/2177 is resolved
+      - name: Pin pip to v25.0 (FIXME)
+        run: pip install pip==25.0
+
       # FIXME OS level dependencies differ between the projects, could be a workflow input
       # libvirt-dev: localstack/localstack-ext
       - name: Install OS packages


### PR DESCRIPTION
# Problem

When running the dependency upgrade in dependent repositories, with `pip==25.1` they can run into the some issues with resolving. With `pip==25.0` this does not happen. See [here](https://github.com/jazzband/pip-tools/issues/2177)

# Solution

Pin pip onto `25.0` until there is a fix in place.