### PR TITLE
master -> main rename, localstack-ext -> localstack-pro rename

### DIFF
--- a/.github/workflows/pr-enforce-no-major-minor.yml
+++ b/.github/workflows/pr-enforce-no-major-minor.yml
@@ -22,4 +22,4 @@ jobs:
           labels: "semver: major, semver: minor"
           add_comment: true
           token: ${{ secrets.github-token }}
-          message: "Currently, only patch changes are allowed on master. Your PR labels ({{ applied }}) indicate that it cannot be merged into the master at this time."
+          message: "Currently, only patch changes are allowed on main. Your PR labels ({{ applied }}) indicate that it cannot be merged into the main at this time."

--- a/.github/workflows/pr-enforce-no-major.yml
+++ b/.github/workflows/pr-enforce-no-major.yml
@@ -22,4 +22,4 @@ jobs:
           labels: "semver: major"
           add_comment: true
           token: ${{ secrets.github-token }}
-          message: "Currently, only minor and patch changes are allowed on master. Your PR labels ({{ applied }}) indicate that it cannot be merged into the master at this time."
+          message: "Currently, only minor and patch changes are allowed on main. Your PR labels ({{ applied }}) indicate that it cannot be merged into the main at this time."

--- a/README.md
+++ b/README.md
@@ -89,14 +89,14 @@ jobs:
 
 ## pr-enforce-no-major
 ```yaml
-name: Enforce no major on master
+name: Enforce no major on main
 
 on:
   pull_request_target:
     types: [labeled, unlabeled, opened, edited, synchronize]
-    # only enforce for PRs targeting the master branch
+    # only enforce for PRs targeting the main branch
     branches:
-    - master
+    - main
 
 jobs:
   enforce-no-major:
@@ -110,14 +110,14 @@ jobs:
 
 ## pr-enforce-no-major-minor
 ```yaml
-name: Enforce no major or minor on master
+name: Enforce no major or minor on main
 
 on:
   pull_request_target:
     types: [labeled, unlabeled, opened, edited, synchronize]
-    # only enforce for PRs targeting the master branch
+    # only enforce for PRs targeting the main branch
     branches:
-    - master
+    - main
 
 jobs:
   enforce-no-major-minor:

--- a/scripts/get_latest_github_metrics.sh
+++ b/scripts/get_latest_github_metrics.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 
 # input params
 PARENT_FOLDER=${1:-target}
-METRICS_ARTIFACTS_BRANCH=${2:-master}
+METRICS_ARTIFACTS_BRANCH=${2:-main}
 
 # ENVs
-REPOSITORY_NAME=${REPOSITORY_NAME:-localstack-ext}
-ARTIFACT_ID=${ARTIFACT_ID:-parity-metric-ext-raw}
+REPOSITORY_NAME=${REPOSITORY_NAME:-localstack-pro}
+ARTIFACT_ID=${ARTIFACT_ID:-parity-metric-pro-raw}
 WORKFLOW=${WORKFLOW:-"Integration Tests"}
 PREFIX_ARTIFACT=${PREFIX_ARTIFACT:-}
 FILTER_SUCCESS=${FILTER_SUCCESS:-1}


### PR DESCRIPTION
## Motivation
Companion to localstack/localstack#12847

Switches branch references from `master` to `main`

## Changes
* Switch default branch references from `master` to `main`
