### PR TITLE
Extend localstack bot to also update code objects related to the newly upgraded pinned dependencies related to azure.

### DIFF
--- a/.github/workflows/upgrade-python-dependencies.yml
+++ b/.github/workflows/upgrade-python-dependencies.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Upgrade all pinned dependencies
         run: make upgrade-pinned-dependencies
 
+      - name: Upgrade all azure api specification objects
+        run: make update-api-spec-usage
+
       - name: Create PR
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
##Motivation

This is one of two related PRs, the other being https://github.com/localstack/localstack-pro/pull/4865. It extends the task of localstack bot so that after upgrading the pinned dependencies it also runs the api-spec-resolver script which updates the codebase to use the latest api specification objects that align with the upgraded pinned dependencies. 

Usually when the localstack bot run and upgrades dependencies in azure, it is following by errors resulting from a mismatch in api spec objects used in code. For example,  upgrading dependencies sometimes changes the API spec and whenever the API specs change, we usually also need to change our implementation. For instance: [Update Azure API](https://github.com/localstack/localstack-ext/pull/4747/files) where we needed to change ContainerObject_2024_02_01 to ContainerObject_2025_05_01  - where ContainerObject can be anything.

Instead of changing many lines of code after every update this PRs change automates this so that it is resolved immediately after any upgrade to dependencies.