### PR TITLE
remove reviewers from upgrade-python-dependencies workflow

### DIFF
--- a/.github/workflows/upgrade-python-dependencies.yml
+++ b/.github/workflows/upgrade-python-dependencies.yml
@@ -42,4 +42,3 @@ jobs:
           commit-message: "Upgrade pinned Python dependencies"
           labels: "area: dependencies, semver: patch"
           token: ${{ secrets.github-token }}
-          reviewers: alexrashed,silv-io


### PR DESCRIPTION
## Motivation
Previously the `upgrade-python-dependencies.yml` workflow was only used by projects where me and @silv-io where over-looking the PRs that were created by this workflow.
Now this workflow is also used by other projects, where it does not make sense to explicitly assign us as reviewers.
This PR removes the `reviewers` config of the step creating the PR, which means that reviewers of the created PRs should be determined by a `CODEOWNERS` file.
/cc @hovaesco 

## Changes
- Do not assign @alexrashed and @silv-io explicitly anymore on dependency upgrade PRs.