### PR TITLE
Add enforce docs labels workflow

### DIFF
--- a/.github/labels-docs.yml
+++ b/.github/labels-docs.yml
@@ -1,0 +1,6 @@
+- color: D73A4A
+  description: Pull request requires documentation updates
+  name: 'needs-docs'
+- color: 0E8A16
+  description: Pull request does not require documentation changes
+  name: 'skip-docs'

--- a/.github/workflows/pr-enforce-docs-labels.yml
+++ b/.github/workflows/pr-enforce-docs-labels.yml
@@ -8,7 +8,7 @@ on:
         description: A GitHub personal access token with write access to the project
 
 jobs:
-  add-to-project:
+  enforce-docs-label:
     name: Add to project
     uses: localstack/meta/.github/workflows/pr-enforce-pr-labels.yml@main
     with:

--- a/.github/workflows/pr-enforce-docs-labels.yml
+++ b/.github/workflows/pr-enforce-docs-labels.yml
@@ -1,0 +1,17 @@
+name: Enforce Docs labels
+
+on:
+  workflow_call:
+    secrets:
+      github-token:
+        required: true
+        description: A GitHub personal access token with write access to the project
+
+jobs:
+  add-to-project:
+    name: Add to project
+    uses: localstack/meta/.github/workflows/pr-enforce-pr-labels.yml@main
+    with:
+      labels: "needs-docs, skip-docs"
+    secrets:
+      github-token: ${{ secrets.github-token }}

--- a/README.md
+++ b/README.md
@@ -128,6 +128,33 @@ jobs:
     secrets:
       github-token: ${{ secrets.REPO_ACCESS_PAT }}
 ```
+## pr-enforce-docs-labels
+
+This reusable workflow enforces that pull requests have appropriate documentation labels (`needs-docs` or `skip-docs`). This helps ensure that documentation requirements are clearly communicated and tracked across repositories.
+
+The workflow can be used like this:
+```yaml
+name: Enforce Docs Labels
+
+on:
+  pull_request_target:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+
+jobs:
+  enforce-docs-labels:
+    uses: localstack/meta/.github/workflows/pr-enforce-docs-labels.yml@main
+    secrets:
+      github-token: ${{ secrets.REPO_ACCESS_PAT }}
+```
+
+### Label Definitions
+
+The documentation labels are defined in `.github/labels-docs.yml`:
+- `needs-docs` (red): Pull request requires documentation updates
+- `skip-docs` (green): Pull request does not require documentation changes
+
+These labels can be synced across repositories using the `sync-labels` workflow.
+
 ## upgrade-python-dependencies
 
 This reusable workflow adds an automated upgrade of dependencies in python repositories.


### PR DESCRIPTION
- Adds `pr-enforce-docs-labels.yml` - reusable workflow that enforces documentation labels (`needs-docs`, `skip-docs`) on pull requests
- Uses the existing `pr-enforce-pr-labels.yml` workflow for consistent label enforcement
- Adds `.github/labels-docs.yml` - definition of documentation labels with consistent colors and descriptions