### PR TITLE
add reusable workflow to update test durations

### DIFF
--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -40,10 +40,6 @@ on:
         default: "UPLOAD_ARTIFACT"
         required: false
         type: string
-      pr-dry-run:
-        description: "If true, simulate PR creation without pushing/opening"
-        type: boolean
-        default: false
       pr-title:
         default: "[Testing] Update test durations"
         required: false
@@ -144,9 +140,6 @@ jobs:
             author: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
             committer: "LocalStack Bot <localstack-bot@users.noreply.github.com>"
             commit-message: "CI: update .test_durations to latest version"
-            draft: true
-            delete-branch: true
-            dry-run: true
             path: ${{ inputs.path }}
             add-paths: ${{ inputs.outPath }}
             labels: ${{ inputs.pr-labels }}


### PR DESCRIPTION
<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation

Centralize and reuse the “update test durations” logic across repositories.
This moves the implementation into the `meta` repo as a reusable workflow so it can be invoked from:
- `localstack/localstack` (https://github.com/localstack/localstack/pull/13170), and
- `localstack/localstack-pro` (https://github.com/localstack/localstack-pro/pull/5297).

This reduces duplication, keeps behavior consistent, and makes future maintenance/changes single-sourced.

## Changes

- Moved existing workflow and made it reusable: `.github/workflows/update-test-durations.yml` in **meta**.
- Parameterized inputs (repo/branch/path/platform/outPath/publishMethod/PR metadata).
- Downloads and merges `pytest-split-durations-<platform>-*` artifacts into `${{ inputs.outPath }}`.
- Publishes result via either:
  - `UPLOAD_ARTIFACT`, or
  - `CREATE_PR` using `peter-evans/create-pull-request`.

<!-- The following sections are optional, but can be useful!

## Testing

Description of how to test the changes

## TODO

What's left to do:

- [ ] ...

-->
