### PR TITLE
use python version from pyenv file

### DIFF
--- a/.github/workflows/upgrade-python-dependencies.yml
+++ b/.github/workflows/upgrade-python-dependencies.yml
@@ -21,11 +21,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Set up Python 3.11
+      - name: Set up Python
         id: setup-python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version-file: '.python-version'
 
       # FIXME OS level dependencies differ between the projects, could be a workflow input
       # libvirt-dev: localstack/localstack-pro


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/13037 we switched to Python 3.13.
The "upgrade dependency lock files" workflow in this repo has the Python version hard-coded to Python 3.11 which creates the wrong lock files due to some incompatibilities.
This PR fixes this such that it assumes a `.python-version` file (pyenv standard) to declare the Python version of the project.
All users of the workflow already have this file, so this change is safe to perform.

## Changes
- Dynamically uses the Python version from the repo instead of hard-coding 3.11