### PR TITLE
CI: Remove Requirement for `calver: ...` Labels

### DIFF
--- a/.github/workflows/pr-enforce-label-groups.yml
+++ b/.github/workflows/pr-enforce-label-groups.yml
@@ -9,15 +9,6 @@ on:
         description: A GitHub personal access token with write access to the project
 
 jobs:
-  calver:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5
-        with:
-          mode: exactly
-          count: 1
-          labels: "calver: patch, calver: monthly, calver: breaking"
-          token: ${{ secrets.github-token }}
   docs:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Changes + Motivation
- This PR removes the requirement for the `calver: ...` labels. The original usage of these labels made sense when we had a code freeze but since we no longer do this they are restrictions which aren't really used for anything.
- Note: This workflow only affects two repositories
- Deciding to keep the label definitions for now for similar reasons for why we kept the `semver: ...` labels (mostly since they can still be used across the org, and for historical reasons it may be worth keeping these here) 