### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @localstack/core-systems


### PR DESCRIPTION
Adds a `CODEOWNERS` file setting @localstack/core-systems as the codeowner of the whole repository.